### PR TITLE
fixing missing foreach dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,87 +1,88 @@
 {
-	"name": "is-typed-array",
-	"version": "1.0.2",
-	"author": "Jordan Harband",
-	"contributors": [
-		{
-			"name": "Jordan Harband",
-			"email": "ljharb@gmail.com"
-		}
-	],
-	"description": "Is this value a JS Typed Array? This module works cross-realm/iframe, does not depend on `instanceof` or mutable properties, and despite ES6 Symbol.toStringTag.",
-	"license": "MIT",
-	"main": "index.js",
-	"scripts": {
-		"test": "npm run lint && npm run tests-only && npm run security",
-		"tests-only": "node --es-staging test.js",
-		"coverage": "covert test.js",
-		"coverage-quiet": "covert test.js --quiet",
-		"lint": "npm run jscs && npm run eslint",
-		"jscs": "jscs *.js",
-		"eslint": "eslint *.js",
-		"eccheck": "editorconfig-tools check *.js **/*.js > /dev/null",
-		"security": "nsp package"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git://github.com/ljharb/is-typed-array.git"
-	},
-	"keywords": [
-		"array",
-		"TypedArray",
-		"typed array",
-		"is",
-		"typed",
-		"Int8Array",
-		"Uint8Array",
-		"Uint8ClampedArray",
-		"Int16Array",
-		"Uint16Array",
-		"Int32Array",
-		"Uint32Array",
-		"Float32Array",
-		"Float64Array",
-		"ES6",
-		"toStringTag",
-		"Symbol.toStringTag",
-		"@@toStringTag"
-	],
-	"dependencies": {},
-	"devDependencies": {
-		"tape": "^4.2.1",
-		"covert": "^1.1.0",
-		"jscs": "^2.2.1",
-		"editorconfig-tools": "^0.1.1",
-		"nsp": "^1.1.0",
-		"eslint": "^1.6.0",
-		"@ljharb/eslint-config": "^1.3.0",
-		"make-arrow-function": "^1.1.0",
-		"make-generator-function": "^1.1.0",
-		"semver": "^5.0.3",
-		"replace": "^0.3.0",
-		"foreach": "^2.0.5",
-		"is-callable": "^1.1.0"
-	},
-	"testling": {
-		"files": "test.js",
-		"browsers": [
-			"iexplore/6.0..latest",
-			"firefox/3.0..6.0",
-			"firefox/15.0..latest",
-			"firefox/nightly",
-			"chrome/4.0..10.0",
-			"chrome/20.0..latest",
-			"chrome/canary",
-			"opera/10.0..latest",
-			"opera/next",
-			"safari/4.0..latest",
-			"ipad/6.0..latest",
-			"iphone/6.0..latest",
-			"android-browser/4.2"
-		]
-	},
-	"engines": {
-		"node": ">= 0.4"
-	}
+  "name": "is-typed-array",
+  "version": "1.0.2",
+  "author": "Jordan Harband",
+  "contributors": [
+    {
+      "name": "Jordan Harband",
+      "email": "ljharb@gmail.com"
+    }
+  ],
+  "description": "Is this value a JS Typed Array? This module works cross-realm/iframe, does not depend on `instanceof` or mutable properties, and despite ES6 Symbol.toStringTag.",
+  "license": "MIT",
+  "main": "index.js",
+  "scripts": {
+    "test": "npm run lint && npm run tests-only && npm run security",
+    "tests-only": "node --es-staging test.js",
+    "coverage": "covert test.js",
+    "coverage-quiet": "covert test.js --quiet",
+    "lint": "npm run jscs && npm run eslint",
+    "jscs": "jscs *.js",
+    "eslint": "eslint *.js",
+    "eccheck": "editorconfig-tools check *.js **/*.js > /dev/null",
+    "security": "nsp package"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/ljharb/is-typed-array.git"
+  },
+  "keywords": [
+    "array",
+    "TypedArray",
+    "typed array",
+    "is",
+    "typed",
+    "Int8Array",
+    "Uint8Array",
+    "Uint8ClampedArray",
+    "Int16Array",
+    "Uint16Array",
+    "Int32Array",
+    "Uint32Array",
+    "Float32Array",
+    "Float64Array",
+    "ES6",
+    "toStringTag",
+    "Symbol.toStringTag",
+    "@@toStringTag"
+  ],
+  "dependencies": {
+    "foreach": "^2.0.5"
+  },
+  "devDependencies": {
+    "tape": "^4.2.1",
+    "covert": "^1.1.0",
+    "jscs": "^2.2.1",
+    "editorconfig-tools": "^0.1.1",
+    "nsp": "^1.1.0",
+    "eslint": "^1.6.0",
+    "@ljharb/eslint-config": "^1.3.0",
+    "make-arrow-function": "^1.1.0",
+    "make-generator-function": "^1.1.0",
+    "semver": "^5.0.3",
+    "replace": "^0.3.0",
+    "foreach": "^2.0.5",
+    "is-callable": "^1.1.0"
+  },
+  "testling": {
+    "files": "test.js",
+    "browsers": [
+      "iexplore/6.0..latest",
+      "firefox/3.0..6.0",
+      "firefox/15.0..latest",
+      "firefox/nightly",
+      "chrome/4.0..10.0",
+      "chrome/20.0..latest",
+      "chrome/canary",
+      "opera/10.0..latest",
+      "opera/next",
+      "safari/4.0..latest",
+      "ipad/6.0..latest",
+      "iphone/6.0..latest",
+      "android-browser/4.2"
+    ]
+  },
+  "engines": {
+    "node": ">= 0.4"
+  }
 }
-


### PR DESCRIPTION
The latest version on npm is missing the `foreach` dependency.

Also, I'm curious, is there any reason a check like in `is-typedarray` isn't sufficient? This module seems overly complicated in comparison.
https://github.com/hughsk/is-typedarray/blob/master/index.js

Or even something like this? What situations might it fail in?
https://github.com/alexanderGugel/is-typed-array/blob/master/index.js