### PR TITLE
deps: drop for-each

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var forEach = require('for-each');
 var availableTypedArrays = require('available-typed-arrays');
 var callBound = require('call-bind/callBound');
 
@@ -23,7 +22,7 @@ var $slice = callBound('String.prototype.slice');
 var toStrTags = {};
 var getPrototypeOf = Object.getPrototypeOf; // require('getprototypeof');
 if (hasToStringTag && gOPD && getPrototypeOf) {
-	forEach(typedArrays, function (typedArray) {
+	Array.prototype.forEach.call(typedArrays, function (typedArray) {
 		var arr = new g[typedArray]();
 		if (Symbol.toStringTag in arr) {
 			var proto = getPrototypeOf(arr);
@@ -38,15 +37,18 @@ if (hasToStringTag && gOPD && getPrototypeOf) {
 }
 
 var tryTypedArrays = function tryAllTypedArrays(value) {
-	var anyTrue = false;
-	forEach(toStrTags, function (getter, typedArray) {
-		if (!anyTrue) {
-			try {
-				anyTrue = getter.call(value) === typedArray;
-			} catch (e) { /**/ }
-		}
-	});
-	return anyTrue;
+	// note: can update syntax to friendlier for..of when dropping support for node 0.10
+	var keys = Object.keys(toStrTags);
+	for (var i = 0; i < keys.length; i++) {
+		var typedArray = keys[i];
+		var getter = toStrTags[typedArray];
+		try {
+			if (getter.call(value) === typedArray) {
+				return true;
+			}
+		} catch (e) { /**/ }
+	}
+	return false;
 };
 
 module.exports = function isTypedArray(value) {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
 	"dependencies": {
 		"available-typed-arrays": "^1.0.5",
 		"call-bind": "^1.0.2",
-		"for-each": "^0.3.3",
 		"gopd": "^1.0.1",
 		"has-tostringtag": "^1.0.0"
 	},

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
 		]
 	},
 	"engines": {
-		"node": ">= 0.4"
+		"node": ">= 0.10"
 	},
 	"auto-changelog": {
 		"output": "CHANGELOG.md",


### PR DESCRIPTION
- Require minimum Node.js version `0.10`
  - Even `0.10` itself went EoL ~10 years ago. Is supporting older versions than this still desirable? Keeping the bump at the conservative minimum to increase likelihood of this being releasable on current major.
- Remove dependency `for-each`
- Performance improvement: Skip redundant iteration in `tryTypedArrays` loop.

@ljharb do you think this sounds reasonable? If so I can address `call-bind` similarly.